### PR TITLE
Remove hard coded path to R & clean up default flags

### DIFF
--- a/middleware/invoke
+++ b/middleware/invoke
@@ -9,5 +9,5 @@
     -w "none" \
     -c "xview -fullscreen -onroot @tool/data/draft-logo-small-color.png" \
     -c "wrwroxy --listenHost 0.0.0.0 --listenPort 8000 --forwardHost 127.0.0.1 --forwardPort 8001 --stream-log --logfile /dev/null" \
-    -C "@tool/bin/wrapprun --host 0.0.0.0 --port 8001 --type shiny --file @@file(#1) /apps/share64/debian7/R/3.4.0/lib/R/library/serenity/app" \
-    -C "@tool/bin/wrapprun --host 0.0.0.0 --port 8001 --type shiny /apps/share64/debian7/R/3.4.0/lib/R/library/serenity/app"
+    -C "@tool/bin/wrapprun --host 0.0.0.0 --port 8001 --type shiny --file @@file(#1) \$env(R_INSTALL_DIR)/lib/R/library/serenity/app" \
+    -C "@tool/bin/wrapprun --host 0.0.0.0 --port 8001 --type shiny \$env(R_INSTALL_DIR)/lib/R/library/serenity/app"

--- a/middleware/invoke
+++ b/middleware/invoke
@@ -8,6 +8,6 @@
     -u wrwroxy-0.1 \
     -w "none" \
     -c "xview -fullscreen -onroot @tool/data/draft-logo-small-color.png" \
-    -c "wrwroxy --listenHost 0.0.0.0 --listenPort 8000 --forwardHost 127.0.0.1 --forwardPort 8001 --stream-log --logfile /dev/null" \
-    -C "@tool/bin/wrapprun --host 0.0.0.0 --port 8001 --type shiny --file @@file(#1) \$env(R_INSTALL_DIR)/lib/R/library/serenity/app" \
-    -C "@tool/bin/wrapprun --host 0.0.0.0 --port 8001 --type shiny \$env(R_INSTALL_DIR)/lib/R/library/serenity/app"
+    -c "wrwroxy --stream-log --logfile /dev/null" \
+    -C "@tool/bin/wrapprun --port 8001 --type shiny --file @@file(#1) \$env(R_INSTALL_DIR)/lib/R/library/serenity/app" \
+    -C "@tool/bin/wrapprun --port 8001 --type shiny \$env(R_INSTALL_DIR)/lib/R/library/serenity/app"


### PR DESCRIPTION
This pull request makes two adjustments to the repository. 
1. Resolves qubeshub.org support ticket #894 by using tcl's $env() array to reference environment variables.
2. Removing flags from wrwroxy and wrapprun commands that match their default value. This is only for cosmetic reasons.